### PR TITLE
Add whitespace when extracting to output path

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -38,7 +38,7 @@ try {
 
             # Extract nodejs from the self-extracting archive file.
             Write-Verbose "Extracting nodejs to $OutputDir"
-            & $ArchivePath -y -o"$OutputDir"
+            & $ArchivePath -y -o "$OutputDir"
 
             # Make sure it completed successfully.
             if ($LastExitCode -ne 0) {


### PR DESCRIPTION
Seeing this exception after we have messages that we are about to extract the archive:

Install-NodeJsPackage : Exception calling "Substring" with "2" argument(s): "Index and length must refer to a location within the
string.

All I can figure ATM is there is a missing whitespace in the call???
