### PR TITLE
fail properly when call returns non-zero exit from Start-Process

### DIFF
--- a/.build/build.ps1
+++ b/.build/build.ps1
@@ -65,11 +65,16 @@ task Compress  Init, {
         throw "File not found: $SevenZipPath`r`nThis script requires the 64-bit version of 7-zip to be installed on this machine."
     }
 
-    Start-Process -FilePath $SevenZipPath `
-                  -ArgumentList @('a', '-bb3', '-r', '-sfx', "$DistDir\nodejs-sfx.exe", '*') `
-                  -WorkingDirectory $NodeJsDir `
-                  -NoNewWindow `
-                  -Wait
+    $process = Start-Process -FilePath $SevenZipPath `
+        -ArgumentList @('a', '-bb3', '-r', '-sfx', "$DistDir\nodejs-sfx.exe", '*') `
+        -WorkingDirectory $NodeJsDir `
+        -NoNewWindow `
+        -PassThru `
+        -Wait
+
+    if($process.ExitCode -ne 0) {
+        exit $process.ExitCode
+    }
 }
 
 


### PR DESCRIPTION
see http://stackoverflow.com/a/16018287/463785 for info. If Compress fails now because of 7zip compress operation, it will terminate the whole build.
