### PR TITLE
Use our VSTS nuget feed. Use the latest stable version of nuget.exe

### DIFF
--- a/.build/_init.ps1
+++ b/.build/_init.ps1
@@ -19,11 +19,10 @@ function global:Build
     try
     {
         # Obtain nuget.exe
-        $NuGetVersion = [version] '3.3.0'
         $NuGetPath = '.\nuget.exe'
-        if (-not (Test-Path $NuGetPath) -or (Get-Item $NuGetPath).VersionInfo.ProductVersion -ne $NuGetVersion)
+        if (-not (Test-Path $NuGetPath))
         {
-            $NuGetUrl = "https://dist.nuget.org/win-x86-commandline/v$NuGetVersion/nuget.exe"
+            $NuGetUrl = "https://dist.nuget.org/win-x86-commandline/latest/nuget.exe"
             Write-Host "Downloading $NuGetUrl"
             Invoke-WebRequest $NuGetUrl -OutFile $NuGetPath
         }

--- a/NuGet.Config
+++ b/NuGet.Config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <configuration>
   <packageSources>
-    <add key="Redgate" value="http://nuget.red-gate.com/api/v2" />
+    <add key="red-gate-vsts-main-v3" value="https://red-gate.pkgs.visualstudio.com/_packaging/Main/nuget/v3/index.json" />
   </packageSources>
 </configuration>


### PR DESCRIPTION
![](https://www.leadingagile.com/wp-content/uploads/2017/03/worksonmymachine.png)